### PR TITLE
Adding more service pages to the prototype

### DIFF
--- a/app/views/baseline/service/dbs-check/consent.html
+++ b/app/views/baseline/service/dbs-check/consent.html
@@ -1,0 +1,49 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Prove your identity to continue
+{% endblock %}
+
+{% block beforeContent %}
+{% include "../../../_includes/phase-banner.html" %}
+  <a class="govuk-back-link" href="/baseline/service/dbs-check/service-start">Back</a>
+{% endblock %}
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="/baseline/authentication/gov-account" method="post">
+
+      <h1 class="govuk-heading-l">Prove your identity to continue</h1>
+        
+      <p>You need to prove your identity before you can continue. You'll need an account to do this.</p>
+      
+      <p>This will help protect you against online identity theft.</p>
+
+      {{ govukCheckboxes({
+      idPrefix: "id-documents",
+      name: "dbs-accept",
+      classes: "govuk-checkboxes--small",
+      fieldset: {
+      },
+      items: [
+        {
+          value: "dbs-accept-privacy",
+          html: "By continuing, I agree that I have read and understood the basic DBS check online application <a href='#'>privacy policy (opens in a new tab)</a>. I understand how the DBS will process my personal data when I'm applying online, before my application has been submitted",
+          checked:  checked("dbs-accept", "dbs-accept-privacy")
+        }
+      ]
+    }) }}
+
+      <input class="govuk-input" id="optin" name="optin" type="hidden" value="yes">
+
+      <button class="govuk-button" data-module="govuk-button">Continue</button>
+
+    </form>
+
+  </div>
+
+</div>
+{% endblock %}

--- a/app/views/baseline/service/dbs-check/return-to-service-success.html
+++ b/app/views/baseline/service/dbs-check/return-to-service-success.html
@@ -1,0 +1,114 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Is this your full name, date of birth and address?
+{% endblock %}
+
+{% block beforeContent %}
+{% include "../../../_includes/phase-banner.html" %}
+{% endblock %}
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <!-- Need to add action or routing here -->
+    <form action=" " method="post">
+
+      <h1 class="govuk-heading-l">Is this your full name, date of birth and address?</h1>
+        
+      <p>This is the name, date of birth and address shared from your GOV.UK One Login:</p>
+
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Name
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['firstName'] }} {{ data['middleName'] }} {{ data['lastName'] or "Sarah Jones" }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Date of birth
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {{ data['date-of-birth-day'] }} {{ data['date-of-birth-month'] }} {{ data['date-of-birth-year'] or "22 10 1993" }}
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Address
+          </dt>
+          <dd class="govuk-summary-list__value">
+            {% if data['address-city-current'] %}
+              {% if data['address-line1-current'] %}
+                {{ data['address-line1-current'] }}<br>
+              {% endif %}
+              {% if data['address-line2-current'] %}
+                {{ data['address-line2-current'] }}<br>
+              {% endif %}
+              {{ data['address-city-current'] }}<br>
+              {% if data['address-county-current'] %}
+                {{ data['address-county-current'] }}<br>
+              {% endif %}
+              {{ data['address-postcode-current'] or 'LS1 3BE' }}
+
+              {% else %}
+                Office 14 <br>
+                New Station St <br>
+                Leeds <br>
+                LS1 5DL
+            {% endif %}
+          </dd>
+        </div>
+      </dl>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+          <h1 class="govuk-fieldset__heading"><span class="govuk-visually-hidden">
+            Is this your full name, date of birth and address?
+          </span></h1>
+        </legend>
+        <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="detailsCheck" name="detailsCheck" type="radio" value="yes">
+            <label class="govuk-label govuk-radios__label" for="detailsCheck">
+              Yes
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="detailsCheck-2" name="detailsCheck" type="radio" value="no">
+            <label class="govuk-label govuk-radios__label" for="detailsCheck-2">
+              No
+            </label>
+          </div>
+        </div>
+      </fieldset>
+
+      <details class="govuk-details govuk-!-margin-top-5">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            My personal information is incorrect, what should I do?
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p>The above personal information has been shared from your GOV.UK One Login.</p>
+          <p>Your name and date of birth have been taken from the details you entered. This is the name that will appear on your basic check result.</p>
+          <p>The above address has been checked with Experian.</p>
+          <p>If you wish to query any of this information, select ‘No’ and ‘Continue’.</p>
+          <p>You will then be redirected so we can help you continue with your application.</p>
+        </div>
+      </details>
+
+      <input class="govuk-input" id="optin" name="optin" type="hidden" value="yes">
+
+      <button class="govuk-button" data-module="govuk-button">Continue</button>
+
+    </form>
+
+  </div>
+
+</div>
+{% endblock %}

--- a/app/views/baseline/service/dbs-check/service-start.html
+++ b/app/views/baseline/service/dbs-check/service-start.html
@@ -1,0 +1,178 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Request a basic DBS check
+{% endblock %}
+
+{% block header %}
+{{ govukHeader({
+homepageUrl: "/",
+serviceName: "",
+serviceUrl: "/",
+containerClasses: "govuk-width-container"
+}) }}
+{% endblock %}
+
+{% block beforeContent %}
+<div class="govuk-breadcrumbs">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="javascript:void(0)">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="javascript:void(0)">Working, jobs and pensions</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="javascript:void(0)">Finding a job</a>
+    </li>
+  </ol>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      Request a basic DBS check
+    </h1>
+
+    <p>Apply for a basic Disclosure and Barring Service (DBS) check to get a copy of your criminal record. This is called ‘basic disclosure’. It costs £23. It’s available for people working in England and Wales.</p>
+
+    <div class="govuk-inset-text">
+      <p>This page is also available in Welsh (<a href="javascript:void(0)">Cymraeg</a>).</p>
+    </div>
+
+    <p>You can also get a basic DBS check if you live in Northern Ireland or Scotland but the job you’re applying for is in England or Wales.</p>
+
+    <div class="govuk-inset-text">
+      <p>There’s a different way to apply if you’re applying for a job in <a href="javascript:void(0)">Northern Ireland</a> or <a href="javascript:void(0)">Scotland</a>.</p>
+    </div>
+
+    <p>The check will only show convictions that are not ‘spent’, for example some types of caution will disappear after 3 months.</p>
+
+    <p>You must be 16 or over to apply.</p>
+
+    <p>It usually takes up to 14 days for you to receive your certificate.</p>
+
+
+
+
+    <h2 class="govuk-heading-m">What you'll need</h2>
+    
+    <p>You might need to create an account and prove your identity before you can apply for a basic DBS check.</p>
+
+    <p>You’ll also need:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>all your addresses for the last 5 years and the dates you lived there</li>
+      <li>your National Insurance number</li>
+      <li>your passport</li>
+      <li>your driving licence</li>
+    </ul>
+
+    <br />
+
+    <form class="form" action="/baseline/service/dbs-check/consent" method="get">
+
+      <div class="govuk-form-group">
+
+        <h2 class="govuk-heading-m">Apply online</h2>
+        <p>The service is available from 8am to 11:30pm.</p>
+
+        <input class="govuk-input" id="service" name="service" type="hidden" value="dbs">
+
+        <button class="govuk-button no-mar-bot govuk-button--start" data-module="govuk-button">
+          Start now
+          <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+          </svg>
+        </button>
+      </div>
+    </form>
+
+
+    <div id="before-you-start">
+      <h2 class="govuk-heading-m">Before you start</h2>
+
+      <div class="gem-c-govspeak govuk-govspeak " data-module="govspeak">
+
+        <p>Make sure a basic <abbr title="Disclosure and Barring Service">DBS</abbr> check is the correct one for you. For certain roles, your employer may need to apply for a higher level of criminal record check.</p>
+
+        <p><a href="javascript:void(0)">Find out if you need a basic <abbr title="Disclosure and Barring Service">DBS</abbr> check</a> or ask your employer if you’re not sure.</p>
+
+        <h2 class="govuk-heading-m">How to pay</h2>
+
+        <p>You can pay for a basic <abbr title="Disclosure and Barring Service">DBS</abbr> check yourself or you can get someone to pay for you - for example, an employer or relative.</p>
+
+        <p>You can pay with a debit or credit card. You can also use Google Pay or Apple Pay.</p>
+
+        <p>If you pay the fee yourself, you need to pay it when you apply.</p>
+
+        <p>If someone else pays, they must pay the fee within 10 days of your application being submitted.</p>
+
+        <h2 class="govuk-heading-m">Get help to use the online service</h2>
+
+        <p>If you need support to apply online, call the <abbr title="Disclosure and Barring Service">DBS</abbr> helpline on 03000 200 190 and select option 2 and then option 1.</p>
+
+        <h2 class="govuk-heading-m">Other ways to apply</h2>
+
+        <p>You can also choose to apply through other companies. <abbr title="Disclosure and Barring Service">DBS</abbr> has a <a href="javascript:void(0)">list of companies</a> you can apply through.</p>
+
+        <h2 class="govuk-heading-m">Requesting your police record</h2>
+
+        <p>You’ll need to <a href="javascript:void(0)">request a police record</a> instead if:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you’re applying for certain visas</li>
+          <li>you want to see your police file without receiving a certificate - this will show up any warnings or cautions that are not on your official criminal record</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Transgender applications</h2>
+
+        <p>Contact the <abbr title="Disclosure and Barring Service">DBS</abbr> transgender applications team if you’re a transgender applicant and you do not want to reveal details of your previous identity to a potential employer.</p>
+
+        <div class="contact" style="border-left: 1px solid #b1b4b6; padding-left: 15px; margin-bottom: 30px; margin-top: 30px;">
+          <p><strong>DBS transgender applications team</strong><br>
+            <a href="javascript:void(0)">sensitive@dbs.gov.uk</a><br>
+            Telephone: 0151 676 1452<br>
+            Monday to Friday, 9am to 5pm<br>
+            <a href="javascript:void(0)">Find out about call charges</a></p>
+        </div>
+
+
+
+      </div>
+    </div>
+
+
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+
+    <!-- The Related items component is not part of GOV.UK Frontend but will be styled if used in the Prototype Kit -->
+
+    <aside class="app-related-items" role="complementary">
+      <h2 class="govuk-heading-m" id="subsection-title">
+        Related content
+      </h2>
+      <nav role="navigation" aria-labelledby="subsection-title">
+        <ul class="govuk-list govuk-!-font-size-16">
+          <li>
+            <a class="govuk-link" href="#">
+              Criminal record checks when you apply for a role
+            </a>
+          </li>
+          <li>
+            <a class="govuk-link" href="#">
+              Find out which DBS check is right for your employee
+            </a>
+          </li>
+
+        </ul>
+      </nav>
+    </aside>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/baseline/service/hmrc-personal-tax-account/hmrc-continue.html
+++ b/app/views/baseline/service/hmrc-personal-tax-account/hmrc-continue.html
@@ -1,0 +1,63 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Home - Personal tax account - GOV.UK
+{% endblock %}
+
+​
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+​
+    <header class="hmrc-page-heading">
+      <p class="hmrc-caption govuk-caption-xl"><span class="govuk-visually-hidden">This section is </span>Personal tax account home</p>
+      <h1 class="govuk-heading-xl">
+        {{ data['firstName'] }} {{ data['middleName'] }} {{ data['lastName'] or "Sarah Jones" }}
+      </h1>
+    </header>
+​
+    <div class="pta-card-container">
+    <div class="pta-card">
+      <h3 class="govuk-heading-s"><a href="#">Latest news and updates</a></h3>
+      <p class="govuk-body">1.25 percentage points uplift in National Insurance contributions</p>
+    </div>
+    <div class="pta-card">
+      <h3 class="govuk-heading-s"><a href="#">Pay As You Earn (PAYE)</a></h3>
+      <p class="govuk-body">Check or update the employment, pension or other income intormation used to work out your PAYE Income Tax and tax codes.</p>
+    </div>
+    <div class="pta-card">
+      <h3 class="govuk-heading-s"><a href="#">National Insurance</a></h3>
+      <p class="govuk-body">You have a National Insurance number to make sure your National Insurance contributions and tax are recorded against your name only.</p>
+    </div>
+  </div>
+​
+  <h3 class="govuk-heading-m">Benefits</h3>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  <div class="pta-card-container">
+  <div class="pta-card">
+    <h3 class="govuk-heading-s"><a href="#">Tax credits</a></h3>
+    <p class="govuk-body">View your next payments and the people on your claim, and make changes to your claim.</p>
+  </div>
+  <div class="pta-card">
+    <h3 class="govuk-heading-s"><a href="#">Child benefit</a></h3>
+    <p class="govuk-body">A tax-free payment to help parents with the cost of brining up children.</p>
+  </div>
+  <div class="pta-card">
+    <h3 class="govuk-heading-s"><a href="#">Marriage Allowance</a></h3>
+    <p class="govuk-body">Transfer part of your Personal Allowance to your partner so they pay less tax.</p>
+  </div>
+  </div>
+​
+  <h3 class="govuk-heading-m">Pensions</h3>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+  <div class="pta-card-container">
+  <div class="pta-card">
+    <h3 class="govuk-heading-s"><a href="../check-state-pension/">State pension</a></h3>
+    <p class="govuk-body">View your State Pension and National Insurance contributions.</p>
+  </div>
+  </div>
+​
+  </div>
+​
+</div>
+{% endblock %}

--- a/app/views/baseline/service/hmrc-personal-tax-account/service-start.html
+++ b/app/views/baseline/service/hmrc-personal-tax-account/service-start.html
@@ -1,0 +1,66 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Personal tax account: sign in or set up
+{% endblock %}
+
+
+{% block beforeContent %}
+
+<div class="govuk-breadcrumbs govuk-breadcrumbs--collapse-on-mobile">
+  <ol class="govuk-breadcrumbs__list">
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="javascript:void(0)">Home</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="javascript:void(0)">Money and tax</a>
+    </li>
+    <li class="govuk-breadcrumbs__list-item">
+      <a class="govuk-breadcrumbs__link" href="javascript:void(0)">Dealing with HMRC</a>
+    </li>
+  </ol>
+</div>
+
+{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">
+      Personal tax account: sign in or set up
+    </h1>
+
+    <p class="govuk-body">Use your personal tax account to check your records and manage your details with HM Revenue and Customs (HMRC).</p>
+    <p class="govuk-body">This service is also available in <a href="#">Welsh (Cymraeg)</a>.</p>
+    <p class="govuk-body">To use this service, you'll need a Government Gateway account or a GOV.UK One Login.</p>
+
+    <div class="govuk-inset-text">
+      There’s a different service to <a href="javascript:void(0)">file your Self Assessment tax return</a> or <a href="javascript:void(0)">report and pay Capital Gains Tax on UK property</a>.
+    </div>
+
+    {{ govukButton({
+      text: "Start now",
+      href: "/baseline/authentication/gov-account",
+      isStartButton: true
+    }) }}
+
+    <h2 class="govuk-heading-m">What you need to know</h2>
+    <p class="govuk-body">You can use your personal tax account to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>check your Income Tax estimate and tax code</li>
+      <li>fill in, send and view a personal tax return</li>
+      <li>claim a tax refund</li>
+      <li>check your income from work in the previous 5 years</li>
+      <li>check how much Income Tax you paid in the previous 5 years</li>
+      <li>check and manage your tax credits</li>
+      <li>check your State Pension</li>
+      <li>track tax forms that you’ve submitted online</li>
+      <li>check or update your Marriage Allowance</li>
+      <li>tell HMRC about a change of name or address</li>
+      <li>check or update benefits you get from work, for example company car details and medical insurance</li>
+      <li>find your National Insurance number</li>
+    </ul>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/baseline/service/hmrc-self-assessment/service-start.html
+++ b/app/views/baseline/service/hmrc-self-assessment/service-start.html
@@ -1,0 +1,45 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+File your self assessment tax return online
+{% endblock %}
+
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      File your self assessment tax return online
+    </h1>
+
+      <p>You can file a tax return online, if, in the last tax year, you:<p>
+    <ul class="govuk-list govuk-list--bullet"> 
+      <li>were self employed</li>
+      <li>received untaxed income, for example from renting property</li>
+    </ul>
+
+    <p class="govuk-body">
+      The deadline for filing a return online is 31 January.
+    </p>
+
+      <p>You’ll need to enter information about your business and your income  
+      </b></p>
+      <h2 class="govuk-heading-m">
+        Sign in to file your return
+      </h2>
+      <p>You must sign in with GOV.UK One Login. If you do not have a GOV.UK One Login, you can create one. </p>
+      <a href="/baseline/authentication/gov-account" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">
+        Start now
+        <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+          <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+        </svg></a>
+        </div>
+      
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/baseline/service/lasting-power-attorney/return-to-service-find-another-way.html
+++ b/app/views/baseline/service/lasting-power-attorney/return-to-service-find-another-way.html
@@ -1,0 +1,66 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+Your identity details confirmed with GOV.UK One Login
+{% endblock %}
+
+{% block header %}
+{{ govukHeader({
+homepageUrl: "/",
+serviceName: "Make and register a lasting power of attorney (LPA)",
+serviceUrl: "/",
+containerClasses: "govuk-width-container"
+}) }}
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "../../_includes/phase-banner.html" %}
+{% endblock %}
+
+{% block content %}
+
+        
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+        <div class="govuk-notification-banner__header">
+          <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+            Important
+          </h2>
+        </div>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">
+            You have been unable to confirm your identity using GOV.UK One Login.
+          </p>
+        </div>
+      </div>
+      
+      <h1 class="govuk-heading-xl">Confirm your identity</h1>
+
+      <p>You need to confirm your identity before the Office of the Public Guardian (OPG) can register your Lasting Power of Attorney.</p>
+
+      <p>You can either:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>return to GOV.UK One Login and try to confirm your identity again</li>
+        <li>ask someone you know to confirm your identity by vouching for you</li>
+      </ul>
+
+      <p>Continue to find out about vouching and who can confirm your identity.</p>
+
+    <form novalidate="" method="post">
+
+    <div class="govuk-button-group">
+  
+      <a href="#" class="govuk-button" data-module="govuk-button">Continue</a>
+    
+      <a id="return-to-tasklist-btn" href="#" class="govuk-button govuk-button--secondary">Return to task list</a>
+    
+    </div>
+
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/baseline/service/lasting-power-attorney/return-to-service.html
+++ b/app/views/baseline/service/lasting-power-attorney/return-to-service.html
@@ -1,0 +1,83 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+Your identity details confirmed with GOV.UK One Login
+{% endblock %}
+
+{% block header %}
+{{ govukHeader({
+homepageUrl: "/",
+serviceName: "Make and register a lasting power of attorney (LPA)",
+serviceUrl: "/",
+containerClasses: "govuk-width-container"
+}) }}
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "../../_includes/phase-banner.html" %}
+{% endblock %}
+
+{% block content %}
+
+        
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      
+      <h1 class="govuk-heading-xl">Your identity details confirmed with GOV.UK One Login</h1>
+
+      {% set dateOfBirth %}
+          {{ data['date-of-birth-day'] }} {{ data['date-of-birth-month'] }} {{ data['date-of-birth-year'] }}
+        {% endset %}
+
+
+        {{ govukSummaryList({
+          classes: "govuk-!-margin-bottom-7",
+          rows: [
+            {
+              key: {
+                text: "First names"
+              },
+              value: {
+                text: data['firstName'] + ' ' + data['middleName']
+              }
+            },
+            {
+              key: {
+                text: "Last name"
+              },
+              value: {
+                text: data['lastName']
+              }
+            },
+            {
+              key: {
+                text: "Date of birth"
+              },
+              value: {
+                text: dateOfBirth
+              }
+            },
+            {
+              key: {
+                text: "Confirmed at"
+              },
+              value: {
+                text: "8 July 2024 at 2:16pm"
+              }
+            }
+          ]
+        }) }}
+    
+
+    <form novalidate="" method="post">
+      
+<button type="submit" class="govuk-button" data-module="govuk-button">Continue</button>
+
+      
+  <input type="hidden" name="csrf" value="qTAZN31e69Ny">
+
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/baseline/service/lasting-power-attorney/service-start.html
+++ b/app/views/baseline/service/lasting-power-attorney/service-start.html
@@ -1,0 +1,42 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Make a Lasting Power of Attorney (LPA)
+{% endblock %}
+
+{% block beforeContent %}
+{% include "../../../_includes/phase-banner.html" %}
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-xl">
+        Confirm your identity
+      </h1>
+
+      <p class="govuk-body">Before you sign your LPA, you need to confirm your identity.</p>
+
+      <p class="govuk-body">Use the GOV.UK One Login service to confirm your identity either online, or at a Post Office. You will need an identity document, for example:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your payslip, P60 or a benefits letter</li>
+        <li>a UK passport</li>
+        <li>a UK driving licence</li>
+      </ul>
+
+      <p class="govuk-body">If you are unable to confirm your identity using GOV.UK One Login, you’ll be given guidance on what to do next.</p>
+
+      <!-- Need to add action or routing here -->
+      <form class="form" action=" " method="post">
+
+        <button class="govuk-button" data-module="govuk-button">Continue</button>
+
+      </form>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/app/views/baseline/service/lasting-power-attorney/task-list-intro.html
+++ b/app/views/baseline/service/lasting-power-attorney/task-list-intro.html
@@ -1,0 +1,71 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+Make a Lasting Power of Attorney (LPA)
+{% endblock %}
+
+{% block beforeContent %}
+{% include "../../../_includes/phase-banner.html" %}
+{% endblock %}
+
+{% block content %}
+
+<style>
+  
+.moj-ticket-panel {
+    display: block;
+    margin-right: 0;
+    flex-wrap: wrap;
+}
+.govuk-\!-margin-bottom-6 {
+    margin-bottom: 20px !important;
+}
+.moj-ticket-panel__content--blue {
+    border-left-color: #1d70b8;
+}
+.moj-ticket-panel__content {
+    display: block;
+    position: relative;
+    background-color: #f3f2f1;
+    padding: 20px;
+    margin-bottom: 15px;
+    flex-grow: 1;
+    border-left: 4px solid rgba(0, 0, 0, 0);
+}
+</style>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        How to confirm your identity and sign the Lasting Power of Attorney (LPA)
+      </h1>
+
+      <p class="govuk-body">There are 3 steps to signing your LPA. You must complete these steps in one go.</p>
+      
+      {{ govukWarningText({
+        text: "Jo Merrill, your certificate provider, must be with you in person when you complete these steps.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      <div class="moj-ticket-panel govuk-!-margin-bottom-6">
+        <div class="moj-ticket-panel__content moj-ticket-panel__content--blue">
+          
+            <h2 class="govuk-heading-m">1. Confirm your identity</h2><div class="govuk-body"><p>This is so we can be sure it’s you that’s about to sign the LPA. It should take less than 5 minutes.</p></div>
+          
+            <h2 class="govuk-heading-m">2. Discuss your LPA with Jo</h2><div class="govuk-body"><p>You should meet in private. Alex Smith should not be there.</p></div>
+          
+            <h2 class="govuk-heading-m">3. Sign your LPA</h2><div class="govuk-body"><p>Sign your LPA online. We will then send Jo Merrill a unique code by text message, that they must enter to prove they were with you.</p></div>
+          
+        </div>
+      </div>
+
+      <div class="govuk-button-group">
+    
+        <a href="/service/lasting-power-attorney/service-start" class="govuk-button" data-module="govuk-button">Continue</a>
+      
+      <a id="return-to-tasklist-btn" href="#" class="govuk-button govuk-button--secondary">Return to task list</a>
+    </div>
+
+
+{% endblock %}


### PR DESCRIPTION
I've added some more service options for use as start and end pages in prototypes:

- Sign up or log in to personal tax account
- File a self assessment tax return online
- DBS check
- Lasting Power of Attorney

Note these aren't hooked up to the URL generator as I'm not sure how we set this up